### PR TITLE
Adding no common initial experiments multiple runs

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -51,9 +51,9 @@ class Config:
         #############################################################################################
         self.run_multiple_experiments: bool = True
         self.start_from_common_initial_experiment: bool = False
-        self.N_initial_exp: int = 2
-        self.N_reps_each_init_exp: int = 3
-        self.N_reps_no_common_initial_exp: int = 5  # If not starting from common initial experiments.
+        self.N_initial_exp: int = 10
+        self.N_reps_each_init_exp: int = 20
+        self.N_reps_no_common_initial_exp: int = 100  # If not starting from common initial experiments.
         self.reps_new_config: list[dict[str, Any]] = [
             {
                 "gen_layers": 1,
@@ -64,9 +64,9 @@ class Config:
             {
                 "gen_layers": 3,
             },
-            # {
-            #     "gen_layers": 4,
-            # },
+            {
+                "gen_layers": 4,
+            },
             # {
             #     "gen_layers": 5,
             # },
@@ -112,10 +112,10 @@ class Config:
         #   - steps_gen/dis: Discriminator and Generator update steps in each iter (1~5).
         #
         #############################################################################################
-        self.epochs: int = 5
-        self.iterations_epoch: int = 10
+        self.epochs: int = 10
+        self.iterations_epoch: int = 300
         self.save_fid_and_loss_every_x_iter: int = 1
-        self.log_every_x_iter: int = 1  # This needs to be a multiple of save_fid_and_loss_every_x_iter
+        self.log_every_x_iter: int = 10  # This needs to be a multiple of save_fid_and_loss_every_x_iter
         self.max_fidelity: float = 0.99
         self.steps_gen: int = 1
         self.steps_dis: int = 1
@@ -159,7 +159,7 @@ class Config:
         #       (In the diagrams above, you would basically choose where that "x" connection goes in those)
         #
         ###############################################################################################
-        self.system_size: int = 2
+        self.system_size: int = 3
         self.extra_ancilla: bool = False
         self.ancilla_mode: Optional[Literal["pass", "project", "trace"]] = "pass"
         self.ancilla_project_norm: Optional[Literal["re-norm", "pass"]] = "re-norm"

--- a/src/config.py
+++ b/src/config.py
@@ -84,8 +84,8 @@ class Config:
         # ---------------------
         #   - load_timestamp: Timestamp to load a previous run (ex. None, 2025-06-06__02-05-10").
         #       + For individual runs, it will load the models from the specified timestamp.
-        #       + For multiple runs, it will load the initial and control experiments from the specified timestamp,
-        #         and then if the initial experiments config matches, only run the new configuration with changes.
+        #       + For multiple runs, it will move to the directory from the specified timestamp,
+        #         and append the new configurations (if common init, it will first check the CFG matches).
         #
         #   - type_of_warm_start: Warm start type for loading models (only if load_timestamp != None).
         #       + "none": No warm start.

--- a/src/config.py
+++ b/src/config.py
@@ -39,22 +39,25 @@ class Config:
         #
         #   - common_initial_experiment: Whether to start from common initial exp. + change, or all from scratch.
         #
-        #   - N_initial_exp: Number of initial experiments to run, without change (default: 5).
+        #     If True:
+        #       + N_initial_exp: Number of initial experiments to run, without change (default: 5).
+        #       + N_reps_each_init_exp: Num of reps for each initial experiment afterwards, with changes (default: 20).
         #
-        #   - N_reps_each_init_exp: Num of reps for each initial experiment afterwards, with changes (default: 20).
-        #
-        #   - N_reps_no_common_initial_exp: Number of repetitions for each new configuration, if not starting from common initial experiments.
+        #     If False:
+        #       + N_reps_no_common_initial_exp: Number of repetitions for each new configuration (default: 100).
         #
         #   - reps_new_config: The configuration changes to run. If starting from common initial experiments,
-        #           then this represent the changes after the initial experiments (+ control with no changes).
+        #         then this represent the changes after the initial experiments (+ control with no changes).
+        #         If not starting from common initial experiments, then this represents the full set of experiments.
         #
         #############################################################################################
         self.run_multiple_experiments: bool = True
         self.common_initial_experiment: bool = True
+        # If common_initial_experiment == true:
         self.N_initial_exp: int = 10
         self.N_reps_each_init_exp: int = 20
-        self.N_reps_no_common_initial_exp: int = 100  # If not starting from common initial experiments.
-        # TODO: Maybe make the reps common in a single parameter, and then use it for both cases?
+        # If common_initial_experiment == false:
+        self.N_reps_no_common_initial_exp: int = 100
 
         self.reps_new_config: list[dict[str, Any]] = [
             {

--- a/src/config.py
+++ b/src/config.py
@@ -37,7 +37,7 @@ class Config:
         #
         #   - run_multiple_experiments: Whether to run multiple experiments.
         #
-        #   - start_from_common_initial_experiment: Whether to start from common initial exp. + change, or all from scratch.
+        #   - common_initial_experiment: Whether to start from common initial exp. + change, or all from scratch.
         #
         #   - N_initial_exp: Number of initial experiments to run, without change (default: 5).
         #
@@ -50,26 +50,28 @@ class Config:
         #
         #############################################################################################
         self.run_multiple_experiments: bool = True
-        self.start_from_common_initial_experiment: bool = False
+        self.common_initial_experiment: bool = True
         self.N_initial_exp: int = 10
         self.N_reps_each_init_exp: int = 20
         self.N_reps_no_common_initial_exp: int = 100  # If not starting from common initial experiments.
+        # TODO: Maybe make the reps common in a single parameter, and then use it for both cases?
+
         self.reps_new_config: list[dict[str, Any]] = [
             {
-                "gen_layers": 1,
+                "extra_ancilla": True,
+                "ancilla_mode": "pass",
+                "ancilla_topology": "disconnected",
             },
             {
-                "gen_layers": 2,
+                "extra_ancilla": True,
+                "ancilla_mode": "pass",
+                "ancilla_topology": "ansatz",
             },
             {
-                "gen_layers": 3,
+                "extra_ancilla": True,
+                "ancilla_mode": "pass",
+                "ancilla_topology": "bridge",
             },
-            {
-                "gen_layers": 4,
-            },
-            # {
-            #     "gen_layers": 5,
-            # },
             # Add more configs here for comparison
         ]
 
@@ -162,9 +164,11 @@ class Config:
         self.system_size: int = 3
         self.extra_ancilla: bool = False
         self.ancilla_mode: Optional[Literal["pass", "project", "trace"]] = "pass"
+        # self.ancilla_1q_gates: Optional[bool] = False
+        # TODO: Add a bool for doing or not doing ancilla 1q gates, and make it work with the rest of the code.
         self.ancilla_project_norm: Optional[Literal["re-norm", "pass"]] = "re-norm"
         self.ancilla_topology: Optional[Literal["trivial", "disconnected", "ansatz", "bridge", "total"]] = "bridge"
-        self.ancilla_connect_to: Optional[int] = 1  # None means connected to last one, otherwise to the specified.
+        self.ancilla_connect_to: Optional[int] = None  # None means connected to last one, otherwise to the specified.
         # TODO: [FUTURE] Decide what to do with trace, make all code work with density matrices, instead than sampling?
 
         #############################################################################################
@@ -178,7 +182,7 @@ class Config:
         #       + "ZZ_X_Z": 2 body Z, 1 body X and 1 body Z terms.
         #
         #############################################################################################
-        self.gen_layers: int = 1  # 2, 3, 5, 10, 20 ...
+        self.gen_layers: int = 4  # 2, 3, 5, 10, 20 ...
         self.gen_ansatz: Literal["XX_YY_ZZ_Z", "ZZ_X_Z"] = "ZZ_X_Z"
 
         #############################################################################################

--- a/src/config.py
+++ b/src/config.py
@@ -143,21 +143,23 @@ class Config:
         #       + "pass": Pass state with its norm after project (keeps norm info, harder train, more effective Ham).
         #
         #   - ancilla_topology: Topology for the ancilla connections:
-        #       |-----------------|-----------------|-------------------|---------------------|----------------------|
-        #       |    "trivial"    |  "disconnected" |      "ansatz"     |       "bridge"      |        "total"       |
-        # |-----|-----------------|-----------------|-------------------|---------------------|----------------------|
-        # | Q0: |  ───|     |───  |  ───|     |───  |  ───|     |─────  |  ───|     |──■────  |  ───|     |──■────── |
-        # | Q1: |  ───|  G  |───  |  ───|  G  |───  |  ───|  G  |─────  |  ───|  G  |──│────  |  ───|  G  |──│─■──── |
-        # | Q2: |  ───|     |───  |  ───|     |───  |  ───|     |──x──  |  ───|     |──│─x──  |  ───|     |──│─│─■── |
-        # |     |                 |                 |              │    |              │ │    |              │ │ │   |
-        # | A:  |  ─────────────  |  ────U...U────  |  ────U...U───■──  |  ────U...U───■─■──  |  ────U...U───■─■─■── |
-        # |     |                 |                 |                   |                     |                      |
-        # |     |        or       |       or        |         or        |           or        |          or          |
-        # |     |                 |                 |                   |                     |                      |
-        # |  M  |                 |                 |     Q0──Q1──Q2    |      Q0──Q1──Q2     |      Q0──Q1──Q2      |
-        # |  A  |  Q0──Q1──Q2  A  |  Q0──Q1──Q2  A  |           "x"|    |      │     "x"│     |      │   │   │       |
-        # |  P  |                 |                 |     A────────     |      A────────      |      A────────       |
-        # |-----|-----------------|-----------------|-------------------|---------------------|----------------------|
+        #           |-----------------|-------------------|---------------------|----------------------|
+        #           |  "disconnected" |      "ansatz"     |       "bridge"      |        "total"       |
+        #     |-----|-----------------|-------------------|---------------------|----------------------|
+        #     | Q0: |  ───|     |───  |  ───|     |─────  |  ───|     |──■────  |  ───|     |──■────── |
+        #     | Q1: |  ───|  G  |───  |  ───|  G  |─────  |  ───|  G  |──│────  |  ───|  G  |──│─■──── |
+        #     | Q2: |  ───|     |───  |  ───|     |──x──  |  ───|     |──│─x──  |  ───|     |──│─│─■── |
+        #     |     |                 |              │    |              │ │    |              │ │ │   |
+        #     | A:  |  ────U...U────  |  ────U...U───■──  |  ────U...U───■─■──  |  ────U...U───■─■─■── |
+        #     |     |                 |                   |                     |                      |
+        #     |     |       or        |         or        |           or        |          or          |
+        #     |     |                 |                   |                     |                      |
+        #     |  M  |                 |     Q0──Q1──Q2    |      Q0──Q1──Q2     |      Q0──Q1──Q2      |
+        #     |  A  |  Q0──Q1──Q2  A  |           "x"|    |      │     "x"│     |      │   │   │       |
+        #     |  P  |                 |     A────────     |      A────────      |      A────────       |
+        #     |-----|-----------------|-------------------|---------------------|----------------------|
+        #
+        #   - do_ancilla_1q_gates: Whether to include 1-qubit gates for the ancilla qubit.
         #
         #   - ancilla_connect_to: If ancilla_topology is "ansatz" or "bridge" connect to this qubit index.
         #       If None, then the ancilla is connected to the last qubit.
@@ -167,10 +169,9 @@ class Config:
         self.system_size: int = 3
         self.extra_ancilla: bool = False
         self.ancilla_mode: Optional[Literal["pass", "project", "trace"]] = "pass"
-        # self.ancilla_1q_gates: Optional[bool] = False
-        # TODO: Add a bool for doing or not doing ancilla 1q gates, and make it work with the rest of the code.
         self.ancilla_project_norm: Optional[Literal["re-norm", "pass"]] = "re-norm"
-        self.ancilla_topology: Optional[Literal["trivial", "disconnected", "ansatz", "bridge", "total"]] = "bridge"
+        self.ancilla_topology: Optional[Literal["disconnected", "ansatz", "bridge", "total"]] = "bridge"
+        self.do_ancilla_1q_gates: Optional[bool] = False  # Whether to include 1-qubit gates for ancilla qubit.
         self.ancilla_connect_to: Optional[int] = None  # None means connected to last one, otherwise to the specified.
         # TODO: [FUTURE] Decide what to do with trace, make all code work with density matrices, instead than sampling?
 
@@ -327,7 +328,7 @@ test_configurations = [
         "system_size": 2,
         "extra_ancilla": True,
         "ancilla_mode": "pass",
-        "ancilla_topology": "trivial",
+        "ancilla_topology": "disconnected",
         "epochs": 1,
         "iterations_epoch": 3,
         "gen_layers": 1,

--- a/src/config.py
+++ b/src/config.py
@@ -35,21 +35,43 @@ class Config:
         #       and not adding the changes (controls), for then comparing the effects of the changes.
         #       Each individual experiment lasting the specified number of epochs and iterations in CFG.
         #
-        #   - run_multiple_experiments: Whether to run multiple experiments with a change in the middle.
+        #   - run_multiple_experiments: Whether to run multiple experiments.
+        #
+        #   - start_from_common_initial_experiment: Whether to start from common initial exp. + change, or all from scratch.
         #
         #   - N_initial_exp: Number of initial experiments to run, without change (default: 5).
         #
         #   - N_reps_each_init_exp: Num of reps for each initial experiment afterwards, with changes (default: 20).
         #
-        #   - reps_new_config: The configuration changes to run, after the initial experiments.
+        #   - N_reps_no_common_initial_exp: Number of repetitions for each new configuration, if not starting from common initial experiments.
+        #
+        #   - reps_new_config: The configuration changes to run. If starting from common initial experiments,
+        #           then this represent the changes after the initial experiments (+ control with no changes).
         #
         #############################################################################################
         self.run_multiple_experiments: bool = True
-        self.N_initial_exp: int = 10
-        self.N_reps_each_init_exp: int = 20
-        self.reps_new_config: dict[str, Any] = {
-            "gen_layers": 4,
-        }
+        self.start_from_common_initial_experiment: bool = False
+        self.N_initial_exp: int = 2
+        self.N_reps_each_init_exp: int = 3
+        self.N_reps_no_common_initial_exp: int = 5  # If not starting from common initial experiments.
+        self.reps_new_config: list[dict[str, Any]] = [
+            {
+                "gen_layers": 1,
+            },
+            {
+                "gen_layers": 2,
+            },
+            {
+                "gen_layers": 3,
+            },
+            # {
+            #     "gen_layers": 4,
+            # },
+            # {
+            #     "gen_layers": 5,
+            # },
+            # Add more configs here for comparison
+        ]
 
         #############################################################################################
         # ---------------------
@@ -90,10 +112,10 @@ class Config:
         #   - steps_gen/dis: Discriminator and Generator update steps in each iter (1~5).
         #
         #############################################################################################
-        self.epochs: int = 10
-        self.iterations_epoch: int = 150
+        self.epochs: int = 5
+        self.iterations_epoch: int = 10
         self.save_fid_and_loss_every_x_iter: int = 1
-        self.log_every_x_iter: int = 10  # This needs to be a multiple of save_fid_and_loss_every_x_iter
+        self.log_every_x_iter: int = 1  # This needs to be a multiple of save_fid_and_loss_every_x_iter
         self.max_fidelity: float = 0.99
         self.steps_gen: int = 1
         self.steps_dis: int = 1
@@ -137,7 +159,7 @@ class Config:
         #       (In the diagrams above, you would basically choose where that "x" connection goes in those)
         #
         ###############################################################################################
-        self.system_size: int = 3
+        self.system_size: int = 2
         self.extra_ancilla: bool = False
         self.ancilla_mode: Optional[Literal["pass", "project", "trace"]] = "pass"
         self.ancilla_project_norm: Optional[Literal["re-norm", "pass"]] = "re-norm"
@@ -156,7 +178,7 @@ class Config:
         #       + "ZZ_X_Z": 2 body Z, 1 body X and 1 body Z terms.
         #
         #############################################################################################
-        self.gen_layers: int = 3  # 2, 3, 5, 10, 20 ...
+        self.gen_layers: int = 1  # 2, 3, 5, 10, 20 ...
         self.gen_ansatz: Literal["XX_YY_ZZ_Z", "ZZ_X_Z"] = "ZZ_X_Z"
 
         #############################################################################################

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,11 @@
 
 from config import CFG
 from tools.data.data_managers import print_and_log
-from tools.training_init import run_multiple_trainings, run_single_training
+from tools.training_init import (
+    run_multiple_trainings_from_common_init_and_later_change,
+    run_multiple_trainings_no_common_init,
+    run_single_training,
+)
 
 
 ##############################################################
@@ -23,7 +27,10 @@ from tools.training_init import run_multiple_trainings, run_single_training
 ##############################################################
 def main():
     if CFG.run_multiple_experiments:
-        run_multiple_trainings()
+        if CFG.start_from_common_initial_experiment:
+            run_multiple_trainings_from_common_init_and_later_change()
+        else:
+            run_multiple_trainings_no_common_init()
     else:
         print_and_log("Running in SINGLE RUN mode.\n", CFG.log_path)
         run_single_training()

--- a/src/main.py
+++ b/src/main.py
@@ -16,8 +16,7 @@
 from config import CFG
 from tools.data.data_managers import print_and_log
 from tools.training_init import (
-    run_multiple_trainings_from_common_init_and_later_change,
-    run_multiple_trainings_no_common_init,
+    run_multiple_trainings,
     run_single_training,
 )
 
@@ -27,10 +26,7 @@ from tools.training_init import (
 ##############################################################
 def main():
     if CFG.run_multiple_experiments:
-        if CFG.start_from_common_initial_experiment:
-            run_multiple_trainings_from_common_init_and_later_change()
-        else:
-            run_multiple_trainings_no_common_init()
+        run_multiple_trainings()
     else:
         print_and_log("Running in SINGLE RUN mode.\n", CFG.log_path)
         run_single_training()

--- a/src/main.py
+++ b/src/main.py
@@ -15,10 +15,7 @@
 
 from config import CFG
 from tools.data.data_managers import print_and_log
-from tools.training_init import (
-    run_multiple_trainings,
-    run_single_training,
-)
+from tools.training_init import run_multiple_trainings, run_single_training
 
 
 ##############################################################

--- a/src/qgan/generator.py
+++ b/src/qgan/generator.py
@@ -320,7 +320,7 @@ class Ansatz:
             for i in range(size):
                 qc.add_gate(QuantumGate("Z", i, angle=0))
             # Ancilla 1q gates for: total, bridge and disconnected:
-            if CFG.extra_ancilla and CFG.ancilla_topology not in ["trivial"]:
+            if CFG.extra_ancilla and CFG.do_ancilla_1q_gates:
                 qc.add_gate(QuantumGate("Z", size, angle=0))
 
             # Then 2 qubit gates:
@@ -369,7 +369,7 @@ class Ansatz:
                 qc.add_gate(QuantumGate("X", i, angle=0))
                 qc.add_gate(QuantumGate("Z", i, angle=0))
             # Ancilla 1q gates for: total, bridge and disconnected:
-            if CFG.extra_ancilla and CFG.ancilla_topology not in ["trivial"]:
+            if CFG.extra_ancilla and CFG.do_ancilla_1q_gates:
                 qc.add_gate(QuantumGate("X", size, angle=0))
                 qc.add_gate(QuantumGate("Z", size, angle=0))
             # Then 2 qubit gates

--- a/src/replot.py
+++ b/src/replot.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module, for manual reploting of a generated_data/MULTIPLE_RUNS/timestamp."""
+"""Module, for manual replotting of a generated_data/MULTIPLE_RUNS/timestamp."""
 
 import os
 
@@ -41,5 +41,5 @@ generate_all_plots(
     log_path,
     n_runs=n_runs,
     max_fidelity=max_fidelity,
-    common_initial_experiments=common_initial_experiment,
+    common_initial_experiment=common_initial_experiment,
 )

--- a/src/replot.py
+++ b/src/replot.py
@@ -1,0 +1,45 @@
+# Copyright 2025 GIQ, Universitat Autònoma de Barcelona
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module, for manual reploting of a generated_data/MULTIPLE_RUNS/timestamp."""
+
+import os
+
+from tools.plot_hub import generate_all_plots
+
+#######################################################################
+# Parameters for the replotting script
+#######################################################################
+time_stamp_to_replot = "2025-07-03__15-03-02"
+n_runs = 5
+max_fidelity = 0.99
+folder_mode = "experiment"  # "experiment" for no common initial vs "initial" for common initial
+
+#######################################################################
+# Replotting script for the specified experiment
+#######################################################################
+# Path to the experiment folder
+base_path = os.path.join("generated_data", "MULTIPLE_RUNS", time_stamp_to_replot)
+log_path = os.path.join(base_path, "replot_log.txt")
+
+print(f"Replotting for MULTIPLE_RUNS/{time_stamp_to_replot} with {n_runs} experiments")
+
+# Plot:
+generate_all_plots(
+    base_path,
+    log_path,
+    n_runs=n_runs,
+    max_fidelity=max_fidelity,
+    folder_mode=folder_mode,
+)

--- a/src/replot.py
+++ b/src/replot.py
@@ -24,7 +24,7 @@ from tools.plot_hub import generate_all_plots
 time_stamp_to_replot = "2025-07-03__15-03-02"
 n_runs = 5
 max_fidelity = 0.99
-folder_mode = "experiment"  # "experiment" for no common initial vs "initial" for common initial
+common_initial_experiment = False
 
 #######################################################################
 # Replotting script for the specified experiment
@@ -41,5 +41,5 @@ generate_all_plots(
     log_path,
     n_runs=n_runs,
     max_fidelity=max_fidelity,
-    folder_mode=folder_mode,
+    common_initial_experiments=common_initial_experiment,
 )

--- a/src/tools/plot_hub.py
+++ b/src/tools/plot_hub.py
@@ -258,8 +258,14 @@ def plot_comparison_all_runs(base_path, log_path, n_runs, folder_mode="initial")
 def plot_avg_best_fidelity_per_run(base_path, log_path, n_runs, max_fidelity=0.99, folder_mode="initial"):
     avgs = []
     for run_idx in range(1, n_runs + 1):
-        changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
-        avgs.append(np.mean(changed_fids) if changed_fids else 0)
+        if folder_mode == "initial":
+            changed_fids = collect_latest_changed_fidelities_nested_run(base_path, run_idx)
+        else:
+            changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
+        if changed_fids:
+            avgs.append(np.mean(changed_fids))
+        else:
+            avgs.append(0)
     plt.figure(figsize=(8, 5))
     plt.bar(range(1, n_runs + 1), avgs, color="C1", alpha=0.8)
     plt.xlabel("Run index")

--- a/src/tools/plot_hub.py
+++ b/src/tools/plot_hub.py
@@ -124,7 +124,7 @@ def collect_latest_changed_fidelities_nested(base_path, folder_mode="initial", r
 
 def plot_recurrence_vs_fidelity(base_path, log_path, run_idx=None, max_fidelity=0.99, folder_mode="initial"):
     control_fids = (
-        collect_max_fidelities_nested(base_path, r"repeated_control", r"\\d+") if folder_mode == "initial" else []
+        collect_max_fidelities_nested(base_path, r"repeated_controls", r"\d+") if folder_mode == "initial" else []
     )
     changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
     # Split last bin at max_fidelity
@@ -135,14 +135,12 @@ def plot_recurrence_vs_fidelity(base_path, log_path, run_idx=None, max_fidelity=
     plt.figure(figsize=(8, 6))
     width = (bins[1] - bins[0]) * 0.4
     bars = []
-    labels = []
     if folder_mode == "initial" and np.any(control_hist):
         bars.append(
             plt.bar(
                 bin_centers - width / 2, control_hist, width=width, label="Control (no change)", alpha=0.7, color="C0"
             )
         )
-        labels.append("Control (no change)")
     if np.any(changed_hist):
         bars.append(
             plt.bar(
@@ -154,7 +152,6 @@ def plot_recurrence_vs_fidelity(base_path, log_path, run_idx=None, max_fidelity=
                 color="C1",
             )
         )
-        labels.append(f"Run {run_idx}" if run_idx else "Experiment Runs")
     plt.xlabel("Maximum Fidelity Reached")
     plt.ylabel("Recurrence (Count)")
     title = "Recurrence vs Maximum Fidelity"
@@ -202,7 +199,7 @@ def collect_latest_changed_fidelities_nested_run(base_path, run_idx):
 
 def plot_comparison_all_runs(base_path, log_path, n_runs, folder_mode="initial"):
     control_fids = (
-        collect_max_fidelities_nested(base_path, r"repeated_control", r"\\d+") if folder_mode == "initial" else []
+        collect_max_fidelities_nested(base_path, r"repeated_controls", r"\d+") if folder_mode == "initial" else []
     )
     bins = np.linspace(0, 1, 21)
     control_hist, _ = np.histogram(control_fids, bins=bins) if control_fids else (np.zeros(len(bins) - 1), bins)

--- a/src/tools/plot_hub.py
+++ b/src/tools/plot_hub.py
@@ -26,6 +26,9 @@ mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 
+########################################################################
+# MAIN PLOTTING FUNCTION
+########################################################################
 def generate_all_plots(base_path, log_path, n_runs, max_fidelity, folder_mode):
     # Plot for each run
     for run_idx in range(1, n_runs + 1):
@@ -41,6 +44,9 @@ def generate_all_plots(base_path, log_path, n_runs, max_fidelity, folder_mode):
     plot_success_percent_per_run(base_path, log_path, n_runs=n_runs, max_fidelity=max_fidelity, folder_mode=folder_mode)
 
 
+########################################################################
+# REAL TIME RUN PLOTTING FUNCTION
+########################################################################
 def plt_fidelity_vs_iter(fidelities, losses, config, indx=0):
     fig, (axs1, axs2) = plt.subplots(1, 2)
     axs1.plot(range(len(fidelities)), fidelities)
@@ -60,6 +66,176 @@ def plt_fidelity_vs_iter(fidelities, losses, config, indx=0):
     plt.close()
 
 
+#########################################################################
+# PLOT INDIVIDUAL RUNS HISTOGRAMS
+#########################################################################
+def plot_recurrence_vs_fid(base_path, log_path, run_idx=None, max_fidelity=0.99, folder_mode="initial"):
+    control_fids = (
+        collect_max_fidelities_nested(base_path, r"repeated_controls", r"\d+") if folder_mode == "initial" else []
+    )
+    changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
+    # Split last bin at max_fidelity
+    bins = [*list(np.linspace(0, max_fidelity, 20)), max_fidelity, 1.0]
+    control_hist, _ = np.histogram(control_fids, bins=bins) if control_fids else (np.zeros(len(bins) - 1), bins)
+    changed_hist, _ = np.histogram(changed_fids, bins=bins)
+    bin_centers = (np.array(bins[:-1]) + np.array(bins[1:])) / 2
+    plt.figure(figsize=(8, 6))
+    width = (bins[1] - bins[0]) * 0.4
+    bars = []
+    if folder_mode == "initial" and np.any(control_hist):
+        bars.append(
+            plt.bar(
+                bin_centers - width / 2, control_hist, width=width, label="Control (no change)", alpha=0.7, color="C0"
+            )
+        )
+    if np.any(changed_hist):
+        bars.append(
+            plt.bar(
+                bin_centers + width / 2,
+                changed_hist,
+                width=width,
+                label=f"Run {run_idx}" if run_idx else "Experiment Runs",
+                alpha=0.7,
+                color="C1",
+            )
+        )
+    plt.xlabel("Maximum Fidelity Reached")
+    plt.ylabel("Recurrence (Count)")
+    title = "Recurrence vs Maximum Fidelity"
+    if run_idx:
+        title += f" (run {run_idx})"
+    elif folder_mode == "experiment":
+        title += " (Experiment Mode)"
+    plt.title(title)
+    if bars:
+        plt.legend()
+    plt.grid(True)
+    save_path = os.path.join(
+        base_path, f"comparison_recurrence_vs_fidelity_run{run_idx}.png" if run_idx else "recurrence_vs_fidelity.png"
+    )
+    plt.tight_layout()
+    plt.savefig(save_path)
+    print_and_log(f"Saved plot to {save_path}", log_path)
+    plt.close()
+
+
+###########################################################################
+# PLOT COMPARISON OF ALL HISTOGRAMS TOGETHER
+###########################################################################
+def plot_comparison_all_runs(base_path, log_path, n_runs, max_fidelity, folder_mode="initial"):
+    control_fids = (
+        collect_max_fidelities_nested(base_path, r"repeated_controls", r"\d+") if folder_mode == "initial" else []
+    )
+    # Split last bin at max_fidelity
+    bins = [*list(np.linspace(0, max_fidelity, 20)), max_fidelity, 1.0]
+    control_hist, _ = np.histogram(control_fids, bins=bins) if control_fids else (np.zeros(len(bins) - 1), bins)
+    bin_centers = (np.array(bins[:-1]) + np.array(bins[1:])) / 2
+    plt.figure(figsize=(10, 7))
+    width = (bins[1] - bins[0]) * 0.7 / (n_runs + (1 if folder_mode == "initial" and np.any(control_hist) else 0))
+    bars = []
+    if folder_mode == "initial" and np.any(control_hist):
+        bars.append(
+            plt.bar(
+                bin_centers - width * (n_runs // 2), control_hist, width=width, label="Control (no change)", alpha=0.7
+            )
+        )
+    colors = plt.cm.tab10.colors
+    for run_idx in range(1, n_runs + 1):
+        if folder_mode == "initial":
+            changed_fids = collect_latest_changed_fidelities_nested_run(base_path, run_idx)
+        else:
+            changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
+        changed_hist, _ = np.histogram(changed_fids, bins=bins)
+        if np.any(changed_hist):
+            bars.append(
+                plt.bar(
+                    bin_centers
+                    + width
+                    * (run_idx - (n_runs + (1 if folder_mode == "initial" and np.any(control_hist) else 0)) // 2),
+                    changed_hist,
+                    width=width,
+                    label=f"Run {run_idx}",
+                    alpha=0.7,
+                    color=colors[(run_idx - 1) % len(colors)],
+                )
+            )
+    plt.xlabel("Maximum Fidelity Reached")
+    plt.ylabel("Recurrence (Count)")
+    title = "Comparison: Recurrence vs Maximum Fidelity (All Runs)"
+    if folder_mode == "experiment":
+        title += " (Experiment Mode)"
+    plt.title(title)
+    if bars:
+        plt.legend()
+    plt.grid(True)
+    save_path = os.path.join(base_path, "comparison_recurrence_vs_fidelity_all.png")
+    plt.tight_layout()
+    plt.savefig(save_path)
+    print_and_log(f"Saved plot to {save_path}", log_path)
+    plt.close()
+
+
+##########################################################################
+# PLOT AVERAGE BEST FIDELITY PER RUN
+##########################################################################
+def plot_avg_best_fid_per_run(base_path, log_path, n_runs, max_fidelity=0.99, folder_mode="initial"):
+    import matplotlib.ticker as mticker
+
+    avgs = []
+    for run_idx in range(1, n_runs + 1):
+        if folder_mode == "initial":
+            changed_fids = collect_latest_changed_fidelities_nested_run(base_path, run_idx)
+        else:
+            changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
+        if changed_fids:
+            avgs.append(np.nanmean(changed_fids))
+        else:
+            avgs.append(0)
+    plt.figure(figsize=(8, 5))
+    x = np.arange(1, n_runs + 1)
+    plt.plot(x, avgs, "o", color="green", label="Avg Best Fidelity", markersize=6)
+    plt.axhline(max_fidelity, color="C0", linestyle="--", label=f"threshold_fidelity={max_fidelity}")
+    plt.xlabel("Run index")
+    plt.ylabel("Average of Best Fidelity Achieved")
+    plt.title("Average Best Fidelity per Run")
+    plt.ylim(0, 1.05)
+    plt.gca().xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    save_path = os.path.join(base_path, "avg_best_fidelity_per_run.png")
+    plt.tight_layout()
+    plt.savefig(save_path)
+    print_and_log(f"Saved plot to {save_path}", log_path)
+    plt.close()
+
+
+##########################################################################
+# PLOT SUCCESS PERCENTAGE PER RUN (> threshold fidelity)
+##########################################################################
+def plot_success_percent_per_run(base_path, log_path, n_runs, max_fidelity=0.99, folder_mode="initial"):
+    import matplotlib.ticker as mticker
+
+    percents = []
+    for run_idx in range(1, n_runs + 1):
+        changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
+        perc = 100 * np.sum(np.array(changed_fids) >= max_fidelity) / len(changed_fids) if changed_fids else 0
+        percents.append(perc)
+    plt.figure(figsize=(8, 5))
+    x = np.arange(1, n_runs + 1)
+    plt.plot(x, percents, "o", color="red", label="Success %", markersize=6)
+    plt.xlabel("Run index")
+    plt.ylabel(f"% of Runs with Fidelity ≥ {max_fidelity}")
+    plt.title("Success Rate per Run")
+    plt.ylim(0, 105)
+    plt.gca().xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
+    plt.tight_layout()
+    save_path = os.path.join(base_path, "success_percent_per_run.png")
+    plt.savefig(save_path)
+    print_and_log(f"Saved plot to {save_path}", log_path)
+    plt.close()
+
+
+##########################################################################
+# HELPER FUNCTIONS TO COLLECT MAX FIDELITIES
+##########################################################################
 def get_max_fidelity_from_file(fid_loss_path):
     if not os.path.exists(fid_loss_path):
         return None
@@ -143,56 +319,6 @@ def collect_latest_changed_fidelities_nested(base_path, folder_mode="initial", r
     return max_fids
 
 
-def plot_recurrence_vs_fid(base_path, log_path, run_idx=None, max_fidelity=0.99, folder_mode="initial"):
-    control_fids = (
-        collect_max_fidelities_nested(base_path, r"repeated_controls", r"\d+") if folder_mode == "initial" else []
-    )
-    changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
-    # Split last bin at max_fidelity
-    bins = [*list(np.linspace(0, max_fidelity, 20)), max_fidelity, 1.0]
-    control_hist, _ = np.histogram(control_fids, bins=bins) if control_fids else (np.zeros(len(bins) - 1), bins)
-    changed_hist, _ = np.histogram(changed_fids, bins=bins)
-    bin_centers = (np.array(bins[:-1]) + np.array(bins[1:])) / 2
-    plt.figure(figsize=(8, 6))
-    width = (bins[1] - bins[0]) * 0.4
-    bars = []
-    if folder_mode == "initial" and np.any(control_hist):
-        bars.append(
-            plt.bar(
-                bin_centers - width / 2, control_hist, width=width, label="Control (no change)", alpha=0.7, color="C0"
-            )
-        )
-    if np.any(changed_hist):
-        bars.append(
-            plt.bar(
-                bin_centers + width / 2,
-                changed_hist,
-                width=width,
-                label=f"Run {run_idx}" if run_idx else "Experiment Runs",
-                alpha=0.7,
-                color="C1",
-            )
-        )
-    plt.xlabel("Maximum Fidelity Reached")
-    plt.ylabel("Recurrence (Count)")
-    title = "Recurrence vs Maximum Fidelity"
-    if run_idx:
-        title += f" (run {run_idx})"
-    elif folder_mode == "experiment":
-        title += " (Experiment Mode)"
-    plt.title(title)
-    if bars:
-        plt.legend()
-    plt.grid(True)
-    save_path = os.path.join(
-        base_path, f"comparison_recurrence_vs_fidelity_run{run_idx}.png" if run_idx else "recurrence_vs_fidelity.png"
-    )
-    plt.tight_layout()
-    plt.savefig(save_path)
-    print_and_log(f"Saved plot to {save_path}", log_path)
-    plt.close()
-
-
 def collect_latest_changed_fidelities_nested_run(base_path, run_idx):
     run_dirs = {}
     for root, dirs, files in os.walk(base_path):
@@ -212,109 +338,3 @@ def collect_latest_changed_fidelities_nested_run(base_path, run_idx):
         if max_fid is not None:
             max_fids.append(max_fid)
     return max_fids
-
-
-def plot_comparison_all_runs(base_path, log_path, n_runs, max_fidelity, folder_mode="initial"):
-    control_fids = (
-        collect_max_fidelities_nested(base_path, r"repeated_controls", r"\d+") if folder_mode == "initial" else []
-    )
-    # Split last bin at max_fidelity
-    bins = [*list(np.linspace(0, max_fidelity, 20)), max_fidelity, 1.0]
-    control_hist, _ = np.histogram(control_fids, bins=bins) if control_fids else (np.zeros(len(bins) - 1), bins)
-    bin_centers = (np.array(bins[:-1]) + np.array(bins[1:])) / 2
-    plt.figure(figsize=(10, 7))
-    width = (bins[1] - bins[0]) * 0.7 / (n_runs + (1 if folder_mode == "initial" and np.any(control_hist) else 0))
-    bars = []
-    if folder_mode == "initial" and np.any(control_hist):
-        bars.append(
-            plt.bar(
-                bin_centers - width * (n_runs // 2), control_hist, width=width, label="Control (no change)", alpha=0.7
-            )
-        )
-    colors = plt.cm.tab10.colors
-    for run_idx in range(1, n_runs + 1):
-        if folder_mode == "initial":
-            changed_fids = collect_latest_changed_fidelities_nested_run(base_path, run_idx)
-        else:
-            changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
-        changed_hist, _ = np.histogram(changed_fids, bins=bins)
-        if np.any(changed_hist):
-            bars.append(
-                plt.bar(
-                    bin_centers
-                    + width
-                    * (run_idx - (n_runs + (1 if folder_mode == "initial" and np.any(control_hist) else 0)) // 2),
-                    changed_hist,
-                    width=width,
-                    label=f"Run {run_idx}",
-                    alpha=0.7,
-                    color=colors[(run_idx - 1) % len(colors)],
-                )
-            )
-    plt.xlabel("Maximum Fidelity Reached")
-    plt.ylabel("Recurrence (Count)")
-    title = "Comparison: Recurrence vs Maximum Fidelity (All Runs)"
-    if folder_mode == "experiment":
-        title += " (Experiment Mode)"
-    plt.title(title)
-    if bars:
-        plt.legend()
-    plt.grid(True)
-    save_path = os.path.join(base_path, "comparison_recurrence_vs_fidelity_all.png")
-    plt.tight_layout()
-    plt.savefig(save_path)
-    print_and_log(f"Saved plot to {save_path}", log_path)
-    plt.close()
-
-
-def plot_avg_best_fid_per_run(base_path, log_path, n_runs, max_fidelity=0.99, folder_mode="initial"):
-    import matplotlib.ticker as mticker
-
-    avgs = []
-    for run_idx in range(1, n_runs + 1):
-        if folder_mode == "initial":
-            changed_fids = collect_latest_changed_fidelities_nested_run(base_path, run_idx)
-        else:
-            changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
-        if changed_fids:
-            avgs.append(np.mean(changed_fids))
-        else:
-            avgs.append(0)
-    plt.figure(figsize=(8, 5))
-    x = np.arange(1, n_runs + 1)
-    plt.plot(x, avgs, "o", color="green", label="Avg Best Fidelity", markersize=6)
-    plt.axhline(max_fidelity, color="C0", linestyle="--", label=f"threshold_fidelity={max_fidelity}")
-    plt.xlabel("Run index")
-    plt.ylabel("Average of Best Fidelity Achieved")
-    plt.title("Average Best Fidelity per Run")
-    plt.ylim(0, 1.05)
-    plt.gca().xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
-    plt.legend()
-    save_path = os.path.join(base_path, "avg_best_fidelity_per_run.png")
-    plt.tight_layout()
-    plt.savefig(save_path)
-    print_and_log(f"Saved plot to {save_path}", log_path)
-    plt.close()
-
-
-def plot_success_percent_per_run(base_path, log_path, n_runs, max_fidelity=0.99, folder_mode="initial"):
-    import matplotlib.ticker as mticker
-
-    percents = []
-    for run_idx in range(1, n_runs + 1):
-        changed_fids = collect_latest_changed_fidelities_nested(base_path, folder_mode, run_idx)
-        perc = 100 * np.sum(np.array(changed_fids) >= max_fidelity) / len(changed_fids) if changed_fids else 0
-        percents.append(perc)
-    plt.figure(figsize=(8, 5))
-    x = np.arange(1, n_runs + 1)
-    plt.plot(x, percents, "o", color="red", label="Success %", markersize=6)
-    plt.xlabel("Run index")
-    plt.ylabel(f"% of Runs with Fidelity ≥ {max_fidelity}")
-    plt.title("Success Rate per Run")
-    plt.ylim(0, 105)
-    plt.gca().xaxis.set_major_locator(mticker.MaxNLocator(integer=True))
-    plt.tight_layout()
-    save_path = os.path.join(base_path, "success_percent_per_run.png")
-    plt.savefig(save_path)
-    print_and_log(f"Saved plot to {save_path}", log_path)
-    plt.close()

--- a/src/tools/plot_hub.py
+++ b/src/tools/plot_hub.py
@@ -243,7 +243,7 @@ def plot_success_percent_per_run(base_path, log_path, n_runs, max_fidelity, comm
         percents.append(perc)
     plt.figure(figsize=(8, 5))
     x = np.arange(1, n_runs + 1)
-    points = plt.plot(x, percents, "o", color="red", label="Runs Succes", markersize=6)
+    points = plt.plot(x, percents, "o", color="red", label="Runs Success", markersize=6)
     # Add value labels above each point
     for xi, yi in zip(x, percents):
         plt.text(xi, yi + 1, f"{yi:.1f}%", ha="center", va="bottom", fontsize=9)

--- a/src/tools/training_init.py
+++ b/src/tools/training_init.py
@@ -73,13 +73,6 @@ def run_multiple_trainings_no_common_init():
     Results are saved in experimentX/ subfolders.
     Plots are generated as in the common-init function.
     """
-    from tools.plot_hub import (
-        plot_avg_best_fidelity_per_run,
-        plot_comparison_all_runs,
-        plot_recurrence_vs_fidelity,
-        plot_success_percent_per_run,
-    )
-
     base_path = f"./generated_data/MULTIPLE_RUNS/{CFG.run_timestamp}"
     CFG.base_data_path = base_path
     CFG.set_results_paths()

--- a/src/tools/training_init.py
+++ b/src/tools/training_init.py
@@ -21,12 +21,7 @@ import traceback
 from config import CFG, test_configurations
 from qgan.training import Training
 from tools.data.data_managers import print_and_log, print_and_log_with_headers
-from tools.plot_hub import (
-    plot_avg_best_fidelity_per_run,
-    plot_comparison_all_runs,
-    plot_recurrence_vs_fidelity,
-    plot_success_percent_per_run,
-)
+from tools.plot_hub import generate_all_plots
 
 # ruff: noqa: E226
 
@@ -77,24 +72,17 @@ def run_multiple_trainings_no_common_init():
     CFG.base_data_path = base_path
     CFG.set_results_paths()
     n_reps = getattr(CFG, "N_reps_no_common_initial_exp", 1)
-    n_runs = len(CFG.reps_new_config)
     try:
         for run_idx, config_dict in enumerate(CFG.reps_new_config, 1):
             execute_run_of_multiple_trainings(config_dict, run_idx, n_reps, base_path)
-        # Plot for each run
-        for run_idx in range(1, n_runs + 1):
-            plot_recurrence_vs_fidelity(
-                base_path, CFG.log_path, run_idx=run_idx, max_fidelity=CFG.max_fidelity, folder_mode="experiment"
-            )
-        # Plot all runs together (overwrites each time)
-        plot_comparison_all_runs(base_path, CFG.log_path, n_runs=n_runs, folder_mode="experiment")
-        # Plot average best fidelity per run
-        plot_avg_best_fidelity_per_run(
-            base_path, CFG.log_path, n_runs=n_runs, max_fidelity=CFG.max_fidelity, folder_mode="experiment"
-        )
-        # Plot percent of runs above max_fidelity per run
-        plot_success_percent_per_run(
-            base_path, CFG.log_path, n_runs=n_runs, max_fidelity=CFG.max_fidelity, folder_mode="experiment"
+
+        # Plot results:
+        generate_all_plots(
+            base_path,
+            CFG.log_path,
+            n_runs=len(CFG.reps_new_config),
+            max_fidelity=CFG.max_fidelity,
+            folder_mode="experiment",
         )
         print_and_log("\nAll multiple training runs (no common init) completed.\n", CFG.log_path)
         print_and_log(
@@ -184,19 +172,12 @@ def run_multiple_trainings_from_common_init_and_later_change():
         ##############################################################
         # Plot results: recurrence vs max fidelity for controls and changed
         ##############################################################
-
-        # Plot for each run
-        for run_idx in range(1, len(CFG.reps_new_config) + 1):
-            plot_recurrence_vs_fidelity(base_path, CFG.log_path, run_idx=run_idx, max_fidelity=CFG.max_fidelity)
-        # Plot all runs together (overwrites each time)
-        plot_comparison_all_runs(base_path, CFG.log_path, n_runs=len(CFG.reps_new_config))
-        # Plot average best fidelity per run
-        plot_avg_best_fidelity_per_run(
-            base_path, CFG.log_path, n_runs=len(CFG.reps_new_config), max_fidelity=CFG.max_fidelity
-        )
-        # Plot percent of runs above max_fidelity per run
-        plot_success_percent_per_run(
-            base_path, CFG.log_path, n_runs=len(CFG.reps_new_config), max_fidelity=CFG.max_fidelity
+        generate_all_plots(
+            base_path,
+            CFG.log_path,
+            n_runs=len(CFG.reps_new_config),
+            max_fidelity=CFG.max_fidelity,
+            folder_mode="initial",
         )
         print_and_log("\nAll multiple training runs completed.\n", CFG.log_path)
         print_and_log(

--- a/src/tools/training_init.py
+++ b/src/tools/training_init.py
@@ -26,9 +26,9 @@ from tools.plot_hub import generate_all_plots
 # ruff: noqa: E226
 
 
-##################################################################
+#################################################################################################################
 # SINGLE RUN MODE:
-##################################################################
+#################################################################################################################
 def run_single_training():
     """
     Runs a single training instance.
@@ -58,9 +58,9 @@ def run_single_training():
         print_and_log(error_msg, CFG.log_path)  # Log to file
 
 
-##################################################################
-# MULTIPLE RUNS MODE:
-##################################################################
+#################################################################################################################
+# MULTIPLE RUNS MODE, WITH COMMON INITIAL EXPERIMENTS:
+#################################################################################################################
 def run_multiple_trainings_no_common_init():
     """
     Runs multiple experiments from scratch (no common initial experiments),
@@ -68,15 +68,23 @@ def run_multiple_trainings_no_common_init():
     Results are saved in experimentX/ subfolders.
     Plots are generated as in the common-init function.
     """
+    ################################################################
+    # Change results directory to MULTIPLE RUNS:
+    ################################################################
     base_path = f"./generated_data/MULTIPLE_RUNS/{CFG.run_timestamp}"
     CFG.base_data_path = base_path
     CFG.set_results_paths()
     n_reps = getattr(CFG, "N_reps_no_common_initial_exp", 1)
     try:
+        ##############################################################
+        # Run multiple training instances with no common initial experiments
+        ##############################################################
         for run_idx, config_dict in enumerate(CFG.reps_new_config, 1):
             execute_run_of_multiple_trainings(config_dict, run_idx, n_reps, base_path)
 
-        # Plot results:
+        ##############################################################
+        # Generate plots for all runs
+        ##############################################################
         generate_all_plots(
             base_path,
             CFG.log_path,
@@ -89,6 +97,9 @@ def run_multiple_trainings_no_common_init():
             "\nAnalysis plots (recurrence vs max fidelity, averages, and success rates) generated.\n", CFG.log_path
         )
     except Exception as e:
+        ##############################################################
+        # Handle exceptions during the training run
+        ##############################################################
         tb_str = traceback.format_exc()
         error_msg = (
             f"\n{'-' * 60}\n"
@@ -113,6 +124,9 @@ def execute_run_of_multiple_trainings(config_dict, run_idx, n_reps, base_path):
         print_and_log(f"\nExperiment {run_idx}, repetition {rep+1} completed.\n", CFG.log_path)
 
 
+#################################################################################################################
+# MULTIPLE RUNS MODE, WITH COMMON INITIAL EXPERIMENTS:
+#################################################################################################################
 def run_multiple_trainings_from_common_init_and_later_change():
     """
     Runs multiple training instances, with a change in the middle.
@@ -170,7 +184,7 @@ def run_multiple_trainings_from_common_init_and_later_change():
             _run_repeated_experiments(n_initial_exp, n_reps_each_init_exp, base_path, f"changed_run{run_idx}")
 
         ##############################################################
-        # Plot results: recurrence vs max fidelity for controls and changed
+        # Generate plots for all runs
         ##############################################################
         generate_all_plots(
             base_path,
@@ -185,6 +199,9 @@ def run_multiple_trainings_from_common_init_and_later_change():
         )
 
     except Exception as e:
+        ##############################################################
+        # Handle exceptions during the training run
+        ##############################################################
         tb_str = traceback.format_exc()
         error_msg = (
             f"\n{'-' * 60}\n"
@@ -249,9 +266,9 @@ def _run_repeated_experiments(n_initial_exp: int, n_reps_each_init_exp: int, bas
         )
 
 
-###################################################################
+#################################################################################################################
 # TESTING MODE:
-###################################################################
+#################################################################################################################
 def run_test_configurations():
     """
     Runs a suite of test configurations.

--- a/src/tools/training_init.py
+++ b/src/tools/training_init.py
@@ -129,6 +129,19 @@ def run_multiple_trainings():
         print_and_log(error_msg, CFG.log_path)
 
 
+def _check_for_previous_multiple_runs():
+    # Check config compatibility
+    prev_log_path = f"./generated_data/MULTIPLE_RUNS/{CFG.load_timestamp}/initial_exp_1/logs/log.txt"
+    if not os.path.exists(prev_log_path):
+        raise RuntimeError(f"Previous run log not found: {prev_log_path}")
+    with open(prev_log_path, "r") as f:
+        log_content = f.read()
+    # Only check for a subset of config fields (excluding run_timestamp and load_timestamp.)
+    config_str = CFG.show_data()
+    if config_str.split("type_of_warm_start")[1] not in log_content:
+        raise RuntimeError("Current config does not match previous initial experiments. Aborting.")
+
+
 #############################################################################
 # Execute multiple training instances with no common initial experiments
 #############################################################################
@@ -193,19 +206,6 @@ def execute_from_common_initial_experiment(base_path):
             setattr(CFG, key, value)
         # Each config gets its own run subdir
         _run_repeated_experiments(n_initial_exp, n_reps_each_init_exp, base_path, f"changed_run{run_idx}")
-
-
-def _check_for_previous_multiple_runs():
-    # Check config compatibility
-    prev_log_path = f"./generated_data/MULTIPLE_RUNS/{CFG.load_timestamp}/initial_exp_1/logs/log.txt"
-    if not os.path.exists(prev_log_path):
-        raise RuntimeError(f"Previous run log not found: {prev_log_path}")
-    with open(prev_log_path, "r") as f:
-        log_content = f.read()
-    # Only check for a subset of config fields (excluding run_timestamp and load_timestamp.)
-    config_str = CFG.show_data()
-    if config_str.split("type_of_warm_start")[1] not in log_content:
-        raise RuntimeError("Current config does not match previous initial experiments. Aborting.")
 
 
 def _run_initial_experiments(n_initial_exp: int, base_path: str):

--- a/src/tools/training_init.py
+++ b/src/tools/training_init.py
@@ -71,23 +71,23 @@ def run_multiple_trainings():
     It also generates plots for all runs after completion, and raises the necessary
     exceptions if any errors occur during the training.
     """
+    ##############################################################
+    # Loading previous MULTIPLE run timestamp if specified:
+    ##############################################################
+    if CFG.load_timestamp is not None:
+        if CFG.common_initial_experiment:
+            _check_for_previous_multiple_runs()
+        CFG.run_timestamp = CFG.load_timestamp
+        print_and_log("Following previous MULTIPLE run, in an already existing directory.\n", CFG.log_path)
+    else:
+        print_and_log("Running MULTIPLE initial, in a new directory.\n", CFG.log_path)
+
     ################################################################
     # Change results directory to MULTIPLE RUNS:
     ################################################################
     base_path = f"./generated_data/MULTIPLE_RUNS/{CFG.run_timestamp}"
     CFG.base_data_path = base_path
     CFG.set_results_paths()
-
-    # TODO: Make sure this works for the no common initial experiments case too.
-    ##############################################################
-    # Loading previous MULTIPLE run timestamp if specified:
-    ##############################################################
-    if CFG.load_timestamp is not None:
-        _check_for_previous_multiple_runs()
-        CFG.run_timestamp = CFG.load_timestamp
-        print_and_log("Following previous MULTIPLE run, only changed experiments will be run.\n", CFG.log_path)
-    else:
-        print_and_log("Running MULTIPLE initial, controls and changed experiments.\n", CFG.log_path)
 
     ##############################################################
     # Execute multiple training instances (with/out common initial exp.)

--- a/tests/qgan/test_ansatz.py
+++ b/tests/qgan/test_ansatz.py
@@ -85,6 +85,7 @@ class TestGeneratorAnsatzAncillaModes():
         modes = ["pass", "project", "trace"]
         topologies = ["disconnected", "ansatz", "bridge", "total"]
 
+        CFG.do_ancilla_1q_gates = True
         CFG.extra_ancilla = True
         CFG.system_size = 4
         CFG.gen_layers = 1

--- a/tests/qgan/test_ansatz.py
+++ b/tests/qgan/test_ansatz.py
@@ -65,21 +65,25 @@ class TestGeneratorAnsatzAncillaModes():
         
         # Add ancilla and check that the number of gates increases
         CFG.extra_ancilla = True
-        for topo in ["trivial", "disconnected", "ansatz", "bridge", "total"]:
+        for topo in ["disconnected", "ansatz", "bridge", "total"]:
             CFG.ancilla_topology = topo
-            gen = Generator(np.matrix(np.ones((2**(CFG.system_size * 2 + (1 if CFG.extra_ancilla else 0)), 1))))
-            gen.qc = Ansatz.get_ansatz_type_circuit(CFG.gen_ansatz)(gen.qc, gen.size, CFG.gen_layers)
-            new_num_gates = len(gen.qc.gates)
+            for ancilla_1q_gate in [True, False]:
+                CFG.do_ancilla_1q_gates = ancilla_1q_gate
+                
+                gen = Generator(np.matrix(np.ones((2**(CFG.system_size * 2 + (1 if CFG.extra_ancilla else 0)), 1))))
+                gen.qc = Ansatz.get_ansatz_type_circuit(CFG.gen_ansatz)(gen.qc, gen.size, CFG.gen_layers)
+                new_num_gates = len(gen.qc.gates)
         
-            if topo != "trivial":
-                assert new_num_gates > old_num_gates
-            else:
-                assert new_num_gates == old_num_gates, "In trivial topology, the number of gates should not change"
+                if topo == "disconnected" and not CFG.do_ancilla_1q_gates:
+                    assert new_num_gates == old_num_gates, "In disconnected topology, if no 1q gates the number of gates should not change"
+                else:
+                    assert new_num_gates > old_num_gates
+                    
             
     def test_ancilla_modes_and_topologies(self):
         # Try all combinations of ancilla_mode and ancilla_topology
         modes = ["pass", "project", "trace"]
-        topologies = ["trivial", "disconnected", "ansatz", "bridge", "total"]
+        topologies = ["disconnected", "ansatz", "bridge", "total"]
 
         CFG.extra_ancilla = True
         CFG.system_size = 4
@@ -101,8 +105,7 @@ class TestGeneratorAnsatzAncillaModes():
                     ancilla_all_gates = [g for g in gen.qc.gates if last_qubit in [g.qubit1, g.qubit2]]
                     ancilla_2q_gates = [g for g in ancilla_all_gates if g.qubit2 is not None]
 
-                    if topo != "trivial":
-                        assert len(ancilla_all_gates) != 0, f"Ancilla gates should not be empty in {topo} topology"
+                    assert len(ancilla_all_gates) != 0, f"Ancilla gates should not be empty in {topo} topology"
 
                     qubit0_all_gates = [g for g in gen.qc.gates if 0 in [g.qubit2, g.qubit1]]
                     qubit1_all_gates = [g for g in gen.qc.gates if 1 in [g.qubit2, g.qubit1]]
@@ -138,9 +141,7 @@ class TestGeneratorAnsatzAncillaModes():
                         assert not ancilla_2q_gates
                         assert len(ancilla_all_gates) != 0
                         assert len(ancilla_all_gates) == len(qubit0_1q_gates)
-                    elif topo == "trivial":
-                        # In trivial topology, there should be no ancilla gates
-                        assert not ancilla_all_gates, f"Ancilla gates should be empty in {topo} topology"
+
 
     def test_save_and_load_with_various_ansatz(self):
         for ansatz in ["XX_YY_ZZ_Z", "ZZ_X_Z"]:
@@ -173,16 +174,18 @@ class TestGeneratorAnsatzAncillaModes():
         old_matrix = gen.qc.get_mat_rep().copy()
         
         CFG.extra_ancilla = True
-        for topo in ["trivial"]: # We only do this, since its where ancilla remains in |0> without entangling
-            CFG.ancilla_topology = topo
-            gen = Generator(np.matrix(np.ones((2**(CFG.system_size * 2 + (1 if CFG.extra_ancilla else 0)), 1))))
-            # Set fixed angles for the gates
-            for gate in gen.qc.gates:
-                gate.angle = 0.456
-            
-            new_matrix = gen.qc.get_mat_rep().copy()
-            
-            # Assert that tracing out the last qubit gives the same matrix as before
-            # Keep every other row and column (i.e., trace out the last qubit)
-            assert np.allclose(old_matrix, new_matrix[::2, ::2]), f"Matrix should be the same when tracing out last qubit in {topo} topology"
+        # We only do this, since its where ancilla remains in |0> without entangling
+        CFG.ancilla_topology = "disconnected"
+        CFG.do_ancilla_1q_gates = False
+        
+        gen = Generator(np.matrix(np.ones((2**(CFG.system_size * 2 + (1 if CFG.extra_ancilla else 0)), 1))))
+        # Set fixed angles for the gates
+        for gate in gen.qc.gates:
+            gate.angle = 0.456
+        
+        new_matrix = gen.qc.get_mat_rep().copy()
+        
+        # Assert that tracing out the last qubit gives the same matrix as before
+        # Keep every other row and column (i.e., trace out the last qubit)
+        assert np.allclose(old_matrix, new_matrix[::2, ::2]), f"Matrix should be the same when tracing out last qubit in {topo} topology"
             

--- a/tests/qgan/test_generator.py
+++ b/tests/qgan/test_generator.py
@@ -64,7 +64,7 @@ class TestGenerator():
     def test_ancilla_modes_and_topologies(self):
         # Try all combinations of ancilla_mode and ancilla_topology
         modes = ["pass", "project", "trace"]
-        topologies = ["trivial", "disconnected", "ansatz", "bridge", "total"]
+        topologies = ["disconnected", "ansatz", "bridge", "total"]
         for mode, topo in itertools.product(modes, topologies):
             CFG.extra_ancilla = True
             CFG.ancilla_mode = mode

--- a/tests/qgan/test_generator_loading.py
+++ b/tests/qgan/test_generator_loading.py
@@ -166,7 +166,7 @@ class TestGeneratorAncillaLoading():
         # Create a new model with different configurations:
         for extra_ancilla in [True, False]:
             CFG.extra_ancilla = extra_ancilla
-            for ancilla_topology in ["trivial", "disconnected", "ansatz", "bridge", "total"]:
+            for ancilla_topology in ["disconnected", "ansatz", "bridge", "total"]:
                 CFG.ancilla_topology = ancilla_topology
 
                 gen_with_ancilla = Generator(np.matrix(np.ones((2**(CFG.system_size * 2 + (1 if CFG.extra_ancilla else 0)), 1))))


### PR DESCRIPTION
### This PR adds:
- [x] The possibility to do different runs in a single execute
- [x] The possibility to not start from some common initial experiments, but directly run separate experiments from scratch and compare them
- [x] Adds a boolean to choose if do 1q gates in the ancilla
- [x] Improve the automatic generation of plots
- [x] Adds the file replot, for necessary manual replots after editing data

#### TODOs:
- [x] Make sure graph generation works correctly for both cases
- [x] Add loading for the no common init case
- [x] Think of a better names for the no_initial (experiment?) and how to join the reps numbers
- [x] Maybe join both code implementations, or extract some common functions like, the base_path change and the loading, and error handling???